### PR TITLE
Faster isNotEmpty on collection

### DIFF
--- a/html5/web/file/terminal/terminal.dart
+++ b/html5/web/file/terminal/terminal.dart
@@ -378,7 +378,7 @@ class Terminal {
       rootDirEntry.createDirectory(folders[0])
       .then((dirEntry) {
         // Recursively add the new subfolder if we still have a subfolder to create.
-        if (folders.length != 0) {
+        if (folders.isNotEmpty) {
           folders.removeAt(0);
           createDir(dirEntry, folders);
         }


### PR DESCRIPTION
Use isNotEmpty instead (https://www.dartlang.org/guides/language/effective-dart/usage#dont-use-length-to-see-if-a-collection-is-empty)